### PR TITLE
Add posix rebar support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ ebin/*.beam
 priv/bin/serial_esock
 src/*~
 *~
+_build/

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,8 @@
+Igor Clark <igor+gen_serial@igorclark.net>
+
+Added basic rebar support for the POSIX build in January 2019.
+
+
 Tom Szilagyi <tomszilagyi@gmail.com>:
 
 Released 0.2 in July 2014 with a backend driver added for POSIX (Linux

--- a/README
+++ b/README
@@ -47,7 +47,7 @@ Building gen_serial on UNIX platforms is pretty simple:
 This will call erl -make with the Emakefile and then invoke the Makefile
 in c_src/posix to compile the POSIX driver backend.
 
-Alternatively, use rebar3 to compile as an OTP app:
+Alternatively, use rebar3 to compile as an OTP app on POSIX platforms:
 
 	rebar3 compile
 

--- a/README
+++ b/README
@@ -47,6 +47,10 @@ Building gen_serial on UNIX platforms is pretty simple:
 This will call erl -make with the Emakefile and then invoke the Makefile
 in c_src/posix to compile the POSIX driver backend.
 
+Alternatively, use rebar3 to compile as an OTP app:
+
+	rebar3 compile
+
 On Windows, the toplevel make.bat may be used to compile the Erlang
 code. The location of your Erlang installation needs to be edited in
 the batch file if it is not C:\Erlang.

--- a/rebar.config
+++ b/rebar.config
@@ -1,0 +1,40 @@
+%% vim: set ft=erlang:
+
+% This file provides rebar3 build instructions for the POSIX version.
+
+{ erl_opts, [ debug_info ] }.
+
+{ deps, [] }.
+
+
+{ plugins, [
+
+    { pc, { git, "https://github.com/blt/port_compiler.git", { tag, "v1.9.1" } } }
+
+] }.
+
+{ provider_hooks, [
+
+    { pre, [
+
+        { compile, { pc, compile }},
+        { clean, { pc, clean }}
+
+    ] }
+
+] }.
+
+{ port_env, [
+
+    { "CFLAGS", "$CFLAGS -Wall -O2 -g -ggdb" }
+
+] }.
+
+{ port_specs, [
+
+    { "priv/bin/serial_esock", [
+		"c_src/erlang_serial.c",
+		"c_src/posix/posix_main.c"
+    ] }
+
+] }.

--- a/src/gen_serial.app.src
+++ b/src/gen_serial.app.src
@@ -1,0 +1,20 @@
+%% vim: ft=erlang:
+{ application, gen_serial,
+ [ { description, "generic serial port driver" },
+  { vsn, "0.3.0" },
+  { registered, [] },
+  { applications,
+   [ kernel,
+    stdlib
+   ] },
+  { env, [] },
+  { modules, [] },
+
+  { licenses, [ "Erlang Public License" ] },
+  { links, [ { "github", "https://github.com/igorclark/gen_serial" } ] },
+  { files, [
+   "c_src",
+   "rebar.config",
+   "src"
+  ] }
+ ] }.

--- a/src/gen_serial.app.src
+++ b/src/gen_serial.app.src
@@ -1,6 +1,6 @@
 %% vim: ft=erlang:
 { application, gen_serial,
- [ { description, "generic serial port driver" },
+ [ { description, "Generic Erlang POSIX serial port driver" },
   { vsn, "0.3.0" },
   { registered, [] },
   { applications,
@@ -11,7 +11,7 @@
   { modules, [] },
 
   { licenses, [ "Erlang Public License" ] },
-  { links, [ { "github", "https://github.com/igorclark/gen_serial" } ] },
+  { links, [ { "github", "https://github.com/tomszilagyi/gen_serial" } ] },
   { files, [
    "c_src",
    "rebar.config",


### PR DESCRIPTION
Hi Tom, thanks for the library, it's been really useful!

I found installing it as a system library inside a Docker container to be more complex than I wanted to deal with, so I added a `rebar.config` to the `gen_serial` project so I could build the POSIX version using `rebar3` and the port compiler `pc`. This way the library can be included as a source dependency in a `rebar3` project, without having to be installed as a system library.

I've tested building it successfully on MacOS and Ubuntu 18.04 LTS; I can only confirm I've tested it working successfully on Ubuntu with a USB-"serial" device, as I've had issues getting either this library or the other [erlang serial library](https://github.com/tonyg/erlang-serial) I found to work on MacOS. The connection hangs after a few messages back and forth with both libraries, so I assume it's some funny MacOS USB/serial thing. I don't have any Windows machines or uses for the Windows version so if anyone needs to make that work with `rebar3` they'll need to add that in.

I've made my own (forked) [version](https://github.com/igorclark/gen_serial) which uses `rebar3`, so it's no biggie for me if you don't want to merge this - just thought it might come in useful for others who might want to build it into a `rebar` project, or have similar Docker/build requirements. 😊

Cheers,
Igor