### PR TITLE
Fix compilation on QNX; fix error in setops/2; add rebar3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ ebin/*.beam
 priv/bin/serial_esock
 src/*~
 *~
+_build
+.rebar3
+rebar3.crashdump

--- a/rebar.config
+++ b/rebar.config
@@ -1,0 +1,9 @@
+{erl_opts, [debug_info]}.
+{deps, []}.
+
+{pre_hooks,
+  [{"(linux|darwin|solaris)", compile, "make -C c_src/posix"},
+    {"(freebsd)", compile, "gmake -C c_src/posix"}]}.
+{post_hooks,
+  [{"(linux|darwin|solaris)", clean, "make -C c_src/posix clean"},
+    {"(freebsd)", clean, "gmake -C c_src/posix clean"}]}.

--- a/src/gen_serial.app.src
+++ b/src/gen_serial.app.src
@@ -1,0 +1,15 @@
+{application, gen_serial,
+ [{description, "Generic serial driver for Erlang on UNIX and Windows"},
+  {vsn, "0.3.0"},
+  {registered, []},
+  {applications,
+   [kernel,
+    stdlib
+   ]},
+  {env,[]},
+  {modules, []},
+
+  {maintainers, ["Tom Szilagyi"]},
+  {licenses, ["Erlang Public License"]},
+  {links, [{"github", "https://github.com/tomszilagyi/gen_serial"}]}
+ ]}.

--- a/src/gen_serial.erl
+++ b/src/gen_serial.erl
@@ -447,10 +447,10 @@ open(Device, Options) ->
       When :: false | true | once,
       Reason :: term().
 
-setopts(PortRef, Options=[{active, _}]) ->
+setopts(#gen_serial{port = Port}, Options=[{active, _}]) ->
 	Cfg = cfg(Options, cfg_defaults()),
 	Active = Cfg#serial_cfg.initially_active,
-	true = port_command(PortRef, <<?PACKET_ACTIVE:8, Active:8>>),
+	true = port_command(Port, <<?PACKET_ACTIVE:8, Active:8>>),
 	ok.
 
 


### PR DESCRIPTION
Hi Tom, thank you for the library.

This small fix allows it to compile on QNX (it has different termios struct, so I used standard POSIX interface functions to set speed instead of direct manipulation of flags inside this struct).

Also flags for hardware flow control are different (they are not in POSIX).

Finally I've added rebar3 support for POSIX version

Edit:
Dialyzer has found one type mismatch in setops/2 function: added the fix for it.

Also there are two warnings related to send/2 function always returning atom 'ok' but expected to maybe return something else. I am not sure what was the intention: either let it also return some kind of error (as stated in its type specs) or remove redundant cases in the following locations:
gen_serial.erl (line 707)
gen_serial_test.erl (line 47)