### PR TITLE
Fix serial port brutal kill from Erlang

### DIFF
--- a/c_src/erlang_serial.c
+++ b/c_src/erlang_serial.c
@@ -702,7 +702,7 @@ DBG_LOG(fprintf(debug_log_file,
 	}
 }
 
-void serial_port_ertsr (struct serial_port* port)
+int serial_port_ertsr (struct serial_port* port)
 {
 	int			r;
 
@@ -738,8 +738,8 @@ void serial_port_ertsr (struct serial_port* port)
 		DBG_LOG(fprintf(debug_log_file, "pipe_read error: %i %s\n",
 			ecode, msg));
 		port->isDead = 1;
-		return;
 	}
+	return r;
 }
 
 void serial_port_ertsw (struct serial_port* port)

--- a/c_src/erlang_serial.h
+++ b/c_src/erlang_serial.h
@@ -489,7 +489,7 @@ extern void serial_port_destroy (struct serial_port* port);
 
 /* Handle the event which indicates we can read data from erts.
  */
-extern void serial_port_ertsr (struct serial_port* port);
+extern int serial_port_ertsr (struct serial_port* port);
 
 /* Handle the event which indicates we can write data to erts.
  */

--- a/c_src/posix/posix_main.c
+++ b/c_src/posix/posix_main.c
@@ -382,7 +382,12 @@ static void main_loop(struct serial_port *port)
 			}
 
 			if ((pollfds[i].fd == STDIN_FILENO) && (pollfds[i].revents & POLLIN)) {
-				serial_port_ertsr(port);
+				if (serial_port_ertsr(port) == 0) {
+					/* Just a safety net: read returned 0 bytes which means end of file
+					 * Erlang closed the port but flag POLLHUP had not been set for some reason
+					 */
+					port->isDead = 1;
+				}
 			} else if ((pollfds[i].fd == STDOUT_FILENO) && (pollfds[i].revents & POLLOUT)) {
 				serial_port_ertsw(port);
 			} else if (pollfds[i].fd == serial_fd) {

--- a/src/gen_serial.erl
+++ b/src/gen_serial.erl
@@ -514,7 +514,7 @@ close(PortRef) ->
 %% receiving data, or flow control has been broken), the close command
 %% may not be able to be processed in a timely fashion. In this case,
 %% this function will wait for <code>Timeout</code> to expire, and then
-%% brutually kill the serial port.  Brutally killing the port will
+%% brutally kill the serial port.  Brutally killing the port will
 %% release all resources correctly, but data will be lost when the output
 %% buffers are destroyed.  If the brutal kill is required, the atom
 %% <code>killed</code> is returned instead of <code>ok</code>.  The
@@ -539,9 +539,9 @@ close(PortRef, Timeout) ->
 	    ok;
 	{error, timeout} ->
 	    case PortRef of
-		_ when is_atom(PortRef) -> exit(whereis(PortRef), normal);
-		_ when is_pid(PortRef) -> exit(PortRef, normal);
-		#gen_serial{pid = Pid} -> exit(Pid, normal)
+		_ when is_atom(PortRef) -> exit(whereis(PortRef), kill);
+		_ when is_pid(PortRef) -> exit(PortRef, kill);
+		#gen_serial{pid = Pid} -> exit(Pid, kill)
 	    end,
 	    killed
     end.


### PR DESCRIPTION
Just a quick fix: calling `exit(Pid, normal)` has no effect since a process can not be remotely killed with the reason `normal`.
I assumed that the intention at that point was to brutally kill the port, so I changed it to `kill`.

The second commit is sort of a work-around a problem when `POLLHUP` flag is not set for some reason on QNX when Erlang closes port. But it keeps `POLLIN` flag and call to `read` returns 0 bytes which is documented to signify end of file. So although this is a work-around it still checks for documented behaviour and should not interfere in any way with the current logic which checks for `POLLHUP` flag, but acts as an additional safety net to make sure the program does not end up hanging forever in background keeping serial port to itself even after we close the port from Erlang program. So based on that I thought you might want to consider merging it.

And thank you again for this great library.