### PR TITLE
Add QNX compatibility for POLLIN flag

### DIFF
--- a/c_src/erlang_serial.h
+++ b/c_src/erlang_serial.h
@@ -9,6 +9,14 @@
 #define ERROR_BAD_LENGTH   EBADMSG
 #endif
 
+#ifdef __QNXNTO__
+/* On QNX, POLLIN is defined as (POLLRDNORM | POLLRDBAND)
+ * but what we really want is just POLLRDNORM.
+ */
+#undef POLLIN
+#define POLLIN POLLRDNORM
+#endif /* __QNXNTO__ */
+
 #define SERIAL_PARITY_NONE	0
 #define SERIAL_PARITY_ODD	1
 #define SERIAL_PARITY_EVEN	2


### PR DESCRIPTION
Hello Tom.

Sorry for bothering you again: this is QNX only tiny fix.
The problem is with `POLLIN` flag which is defined on QNX as `(POLLRDNORM | POLLRDBAND)` but what we really want is just `POLLRDNORM`.
This should not affect builds for other OSes so I hope you will find appropriate to merge it.

Thanks